### PR TITLE
fix path to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Usage
 
 Create roles and permissions through the included `RodrigoPedra\LaravelSimpleACL\Models\Role` and
-`RodrigoPedra\LaravelSimpleACL\Models\Permission` Eloquent models.
+`\RodrigoPedra\LaravelSimpleACL\Models\Permission` Eloquent models.
 
 Permissions are meant to be grouped into a role, you can create a database seeder, or migration for
 your initial setup, for example:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Usage
 
 Create roles and permissions through the included `RodrigoPedra\LaravelSimpleACL\Models\Role` and
-`\RodrigoPedra\LaravelSimpleACL\Models\Permission` Eloquent models.
+`RodrigoPedra\LaravelSimpleACL\Models\Permission` Eloquent models.
 
 Permissions are meant to be grouped into a role, you can create a database seeder, or migration for
 your initial setup, for example:
@@ -61,7 +61,7 @@ $user->attachRole(Role::hasLabel('admin')->first());
 $user->detachRole(Role::hasLabel('leader')->first());
 ```
 
-If you add the `RodrigoPedra\LaravelSimpleACL\Http\Middleware\LoadSimpleACL` middleware 
+If you add the `\RodrigoPedra\LaravelSimpleACL\Http\Middleware\LoadSimpleACL` middleware 
 to your middleware stack, you can use Laravel's gate to check for permissions:
 
 ```php

--- a/src/Concerns/HasACL.php
+++ b/src/Concerns/HasACL.php
@@ -130,12 +130,12 @@ trait HasACL
     {
         $this->setRelation(
             'roles',
-            Cache::rememberForever($this->makeACLCacheKey('roles'), static fn () => $this->roles()->get()),
+            Cache::rememberForever($this->makeACLCacheKey('roles'), fn () => $this->roles()->get()),
         );
 
         $this->setRelation(
             'permissions',
-            Cache::rememberForever($this->makeACLCacheKey('permissions'), static fn () => $this->permissions()->get()),
+            Cache::rememberForever($this->makeACLCacheKey('permissions'), fn () => $this->permissions()->get()),
         );
     }
 


### PR DESCRIPTION
fix for the middleware path, following the laravel standard, just to make it easy to copy and error-free for novice users